### PR TITLE
Convert Plumber2 data to FLUXNET formatting

### DIFF
--- a/R/get_vpd_day_fluxnet2015.R
+++ b/R/get_vpd_day_fluxnet2015.R
@@ -72,22 +72,13 @@ get_vpd_day_fluxnet2015_byfile <- function(filename_hh, write=FALSE){
       stop(paste("Half-hourly file does not exist:", filename_hh))
     } 
     
-    # else if (length(filename_hh)>1){
-    #   warning("Reading only largest file available")
-    #   file.info_getsize <- function(filn){
-    #     file.info(filn)$size
-    #   }
-    #   size_vec <- purrr::map_dbl(as.list(filename_hh), ~file.info_getsize(.))
-    #   filename_hh <- filename_hh[which.max(size_vec)]
-    # }
-    
     df <- readr::read_csv(filename_hh) %>% 
       dplyr::mutate( date_start = lubridate::ymd_hm( TIMESTAMP_START ),
                      date_end   = lubridate::ymd_hm( TIMESTAMP_END ) ) %>%
       dplyr::mutate( date = date_start ) %>% 
       
       ## retain only daytime data = when incoming shortwave radiation is positive
-      dplyr::filter(SW_IN_F>0) %>% 
+      dplyr::filter(SW_IN_F > 0) %>% 
       
       ## take mean over daytime values
       dplyr::mutate(date_day = lubridate::as_date(date_start)) %>% 

--- a/R/read_plumber.R
+++ b/R/read_plumber.R
@@ -7,6 +7,7 @@
 #'
 #' @param site fluxnet site name
 #' @param path path with plumber2 data (both flux and meteo data files)
+#' @param fluxnet_format convert to fluxnet formatting (TRUE/FALSE)
 #' @param meta_data return meta-data TRUE/FALSE
 #'
 #' @return data frame with merged meteo and flux data
@@ -15,8 +16,12 @@
 read_plumber <- function(
   site = "AT-Neu",
   path,
+  fluxnet_format = FALSE,
   meta_data = FALSE
 ){
+  
+  # CRAN settings
+  IGBP_veg_long <- NULL
   
   # list all files
   files <- list.files(
@@ -34,7 +39,7 @@ read_plumber <- function(
   # cut back on read times by only reading
   # flux data when extracting meta-data
   if (meta_data) {
-    files <- files[grepl(glob2rx("*_Flux.nc"), files)]
+    files <- files[grepl(utils::glob2rx("*_Flux.nc"), files)]
   }
   
   df <- lapply(files, function(file){
@@ -97,10 +102,88 @@ read_plumber <- function(
   # only return meta-data if requested
   # don't merge with met data
   if (!meta_data) {
-    all <- df
-  } else {
+    print("join")
     # combine met and flux data
     all <- left_join(df[[1]], df[[2]])
+  } else {
+    all <- df
+  }
+  
+  # format data as fluxnet compatible
+  if (fluxnet_format && !meta_data) {
+    # convert time, and only return
+    # FLUXNET formatted columns
+    
+    all <- all %>%
+      mutate(
+        TIMESTAMP_START = format(time, "%Y%m%d%H%M"),
+        TIMESTAMP_END = format(time + 30 * 60, "%Y%m%d%H%M")
+      )
+    
+    keys <- c(
+      # MICROMET
+      P = "Precip", # in mm -s
+      TA_F = "Tair",
+      SW_IN_F = "SWdown",
+      LW_IN_F = "LWdown",
+      VPD_F = "VPD",
+      WS_F = "Wind",
+      PA_F = "Psurf",
+      CO2_F = "CO2air",
+      # FLUXES
+      NETRAD = "Rnet",
+      USTAR = "Ustar",
+      SW_OUT = "SWup",
+      LE_F_MDS = "Qle",
+      LE_CORR = "Qle_cor",
+      H_F_MDS = "Qh",
+      H_CORR = "Qh_cor",
+      NEE_VUT_REF = "NEE",
+      GPP_VUT_REF = "GPP", # uncertain
+      GPP_VUT_REF_SE = "GPP_se", # uncertain
+      GPP_DT_VUT_REF = "GPP_DT",
+      GPP_DT_VUT_SE = "GPP_DT_se",
+      RECO_NT_VUT_REF = "Resp",
+      RECO_NT_VUT_SE = "Resp_se"
+    )
+    
+    # columns to select
+    loc <- names(keys[which(keys %in% colnames(all))])
+    
+    # loop over key and rename columns
+    for(i in 1:length(keys)) {
+      key <- keys[i]
+      if(key %in% colnames(all)) {
+        new_name <- as.character(names(key))
+        old_name <- as.character(key)
+        all <- all %>%
+          dplyr::rename(
+           !!new_name := !!old_name
+          )
+      }
+    }
+    
+  # return fluxnet selection
+  all  <- all %>%
+      select(
+        TIMESTAMP_START,
+        TIMESTAMP_END,
+        !!loc
+      )
+  
+  # remaining unit conversions
+  # K to C
+  # mm s-1 to mm (sum)
+  # other conversions
+  # https://github.com/aukkola/FluxnetLSM/blob/a256ffc894ed8182f9399afa1d83dea43ac36a95/R/Conversions.R
+  all <- all %>%
+    mutate(
+      P = P * 60 * 30, # mm/s to mm
+      TA_F = TA_F - 273.15, # K to C
+      PA_F = PA_F / 1000, # Pa to kPa
+      CO2_F = CO2_F # ppm to umolCO2 mol-1
+    )
+  
   }
   
   # return the merged file

--- a/analysis/test_plumber_to_fluxnet_conversion.R
+++ b/analysis/test_plumber_to_fluxnet_conversion.R
@@ -1,0 +1,19 @@
+# helping draft a script to convert the plumber data
+# to a fluxnet compatible format in order to process
+# data using the current ingestr routines rather
+# than writing another set of code for plumber data
+
+library(tidyverse)
+source("R/read_plumber.R")
+
+# read in demo data
+df <- read_plumber(
+  site = "AR-SLu",
+  path = "~/Desktop/flux_data/",
+  fluxnet_format = TRUE,
+  meta_data = FALSE
+)
+
+print(str(df))
+
+

--- a/analysis/test_plumber_to_fluxnet_conversion.R
+++ b/analysis/test_plumber_to_fluxnet_conversion.R
@@ -11,7 +11,8 @@ df <- read_plumber(
   site = "AR-SLu",
   path = "~/Desktop/flux_data/",
   fluxnet_format = TRUE,
-  meta_data = FALSE
+  meta_data = FALSE,
+  out_path = "~/Desktop/flux_data/"
 )
 
 print(str(df))

--- a/inst/extdata/.~lock.FLX_FR-Pue_FLUXNET2015_FULLSET_HH_2007-2007_2-3.csv#
+++ b/inst/extdata/.~lock.FLX_FR-Pue_FLUXNET2015_FULLSET_HH_2007-2007_2-3.csv#
@@ -1,1 +1,0 @@
-,khufkens,mistral,21.01.2022 15:18,file:///home/khufkens/.config/libreoffice/4;

--- a/man/read_plumber.Rd
+++ b/man/read_plumber.Rd
@@ -4,14 +4,25 @@
 \alias{read_plumber}
 \title{Reads plumber2 netcdf data}
 \usage{
-read_plumber(site = "AT-Neu", path, meta_data = FALSE)
+read_plumber(
+  site = "AT-Neu",
+  path,
+  fluxnet_format = FALSE,
+  meta_data = FALSE,
+  out_path
+)
 }
 \arguments{
 \item{site}{fluxnet site name}
 
 \item{path}{path with plumber2 data (both flux and meteo data files)}
 
+\item{fluxnet_format}{convert to fluxnet formatting (TRUE/FALSE)}
+
 \item{meta_data}{return meta-data TRUE/FALSE}
+
+\item{out_path}{where to store the converted data if converted to
+fluxnet formatting}
 }
 \value{
 data frame with merged meteo and flux data


### PR DESCRIPTION
Adding conversions and checking units + missing data, output can be written to FLUXNET data standards (full conversion of the dataset). Some data standards still need to be sorted.